### PR TITLE
docs: fix typos in AI-generated install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This application provides real-time audio visualization from microphone input wi
 1. **Prerequisites**: Ensure you have Node.js and npm or yarn installed.
 2. **Installation**:
     ```sh
-    git clone https://github.com/your-username/spectrum-demo.git
-    cd spectrum-demo
+    git clone https://github.com/BSoDium/spectrum-visualizer-demo.git
+    cd spectrum-visualizer-demo
     npm install
     # or
     yarn install


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the repository URL and directory name to reflect the new project name. 

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R18): Updated repository URL from `https://github.com/your-username/spectrum-demo.git` to `https://github.com/BSoDium/spectrum-visualizer-demo.git` and changed directory name from `spectrum-demo` to `spectrum-visualizer-demo`.